### PR TITLE
chore: remove shamefully-flatten

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,10 @@
 # bonde-microservices
 
-Instalar tipos do typescript somente na raiz do projeto, com o comando `pnpm i --shamefully-flatten -D @types/<pkg-name>`
-
 ## Commands
 
 #### Install
 ```
-pnpm m i --shamefully-flatten
+pnpm m i
 ```
 ---
 #### Delete `node_modules` recursively

--- a/packages/webhooks-auth/Dockerfile
+++ b/packages/webhooks-auth/Dockerfile
@@ -6,7 +6,7 @@ WORKDIR /usr/src/app
 
 COPY ./ .
 
-RUN pnpm m i --shamefully-flatten -- bonde-microservices bonde-webhooks-auth
+RUN pnpm m i -- bonde-microservices bonde-webhooks-auth
 
 RUN pnpm m run build --filter bonde-webhooks-auth
 

--- a/packages/webhooks-registry/Dockerfile
+++ b/packages/webhooks-registry/Dockerfile
@@ -6,7 +6,7 @@ WORKDIR /usr/src/app
 
 COPY ./ .
 
-RUN pnpm m i --shamefully-flatten -- bonde-microservices bonde-webhooks-registry
+RUN pnpm m i -- bonde-microservices bonde-webhooks-registry
 
 RUN pnpm m run build --filter bonde-webhooks-registry
 

--- a/packages/webhooks-zendesk-ticket/Dockerfile
+++ b/packages/webhooks-zendesk-ticket/Dockerfile
@@ -6,7 +6,7 @@ WORKDIR /usr/src/app
 
 COPY ./ .
 
-RUN pnpm m i --shamefully-flatten -- bonde-microservices bonde-webhooks-zendesk-ticket
+RUN pnpm m i -- bonde-microservices bonde-webhooks-zendesk-ticket
 
 RUN pnpm m run build --filter bonde-webhooks-zendesk-ticket
 

--- a/packages/webhooks-zendesk/Dockerfile
+++ b/packages/webhooks-zendesk/Dockerfile
@@ -6,7 +6,7 @@ WORKDIR /usr/src/app
 
 COPY ./ .
 
-RUN pnpm m i --shamefully-flatten -- bonde-microservices bonde-webhooks-zendesk
+RUN pnpm m i -- bonde-microservices bonde-webhooks-zendesk
 
 RUN pnpm m run build --filter bonde-webhooks-zendesk
 


### PR DESCRIPTION
#### Contexto

Com a retirada do ts-node-dev, não é mais necessário o uso do --shamefully-flatten do pnpm. Isso significa em uma melhoria no processo de instalação e no funcionamento em geral das dependências.