### PR TITLE
Feature/cli zendesk ticket

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -49,12 +49,12 @@ pipeline:
       status: success
       branch: [hotfix/*, release/*, feature/*, support/*, develop]
 
-  zendesk-ticket-staging-publish:
+  cli-ticket-staging-publish:
     image: plugins/docker
-    repo: nossas/bonde-webhooks-zendesk-ticket
+    repo: nossas/bonde-cli-zendesk-ticket
     group: publishing
     secrets: [ docker_username, docker_password ]
-    dockerfile: packages/webhooks-zendesk-ticket/Dockerfile
+    dockerfile: packages/cli-zendesk-ticket/Dockerfile
     tags:
       - ${DRONE_BRANCH/\//-}
     when:

--- a/packages/cli-zendesk-ticket/src/countTickets.ts
+++ b/packages/cli-zendesk-ticket/src/countTickets.ts
@@ -6,41 +6,22 @@ export interface TicketIds {
   [s: number]: Ticket
 }
 
-interface Requester {
+export interface Requester {
+  id: number
   atendimentos_em_andamento: number
   atendimento__concluído: number
   encaminhamentos: number
 }
 
-interface Requesters {
+export interface Requesters {
   [s: number]: Requester
 }
 
-const countTickets = async (tickets: Ticket[], ticketIds: TicketIds) => {
+const countTickets = async (tickets: Ticket[], ticketsByTicketId: TicketIds) => {
   const requesters: Requesters = {}
   const promises = tickets.map(async i => {
     let type: 'voluntaria' | 'msr' | null = null
     if (!i.link_match) {
-      console.log('Não tem link match', i)
-      return
-    }
-
-    let matchId: number
-    try {
-      matchId = Number(i.link_match.split('/').slice(-1)[0])
-    } catch (e) {
-      console.log('Falhou ao gerar o link do match!', i.id)
-      return
-    }
-
-    if (isNaN(matchId)) {
-      console.log('É NaN', i.id)
-      return
-    }
-
-    const ticketId = ticketIds[matchId]
-    if (!ticketId) {
-      console.log('Ticket match parece que não existe! :(', matchId)
       return
     }
 
@@ -56,14 +37,15 @@ const countTickets = async (tickets: Ticket[], ticketIds: TicketIds) => {
 
     if (type === 'msr') {
       // Cria um pivô e inicializa o valor
-      let requester_pivot = requesters[ticketId.requester_id]
-      if (!requesters[ticketId.requester_id]) {
-        requesters[ticketId.requester_id] = {
+      let requester_pivot = requesters[i.requester_id]
+      if (!requesters[i.requester_id]) {
+        requesters[i.requester_id] = {
+          id: i.requester_id,
           atendimentos_em_andamento: 0,
           atendimento__concluído: 0,
           encaminhamentos: 0
         }
-        requester_pivot = requesters[ticketId.requester_id]
+        requester_pivot = requesters[i.requester_id]
       }
 
       // Atualiza os atendimentos em andamento:
@@ -83,6 +65,7 @@ const countTickets = async (tickets: Ticket[], ticketIds: TicketIds) => {
   })
 
   await Promise.all(promises)
+  return requesters
 }
 
 export default countTickets

--- a/packages/cli-zendesk-ticket/src/countTickets.ts
+++ b/packages/cli-zendesk-ticket/src/countTickets.ts
@@ -8,9 +8,9 @@ export interface TicketIds {
 
 export interface Requester {
   id: number
-  atendimentos_em_andamento: number
-  atendimento__concluído: number
-  encaminhamentos: number
+  atendimentos_em_andamento_calculado_: number
+  atendimentos_concludos_calculado_: number
+  encaminhamentos_realizados_calculado_: number
 }
 
 export interface Requesters {
@@ -41,20 +41,20 @@ const countTickets = async (tickets: Ticket[], ticketsByTicketId: TicketIds) => 
       if (!requesters[i.requester_id]) {
         requesters[i.requester_id] = {
           id: i.requester_id,
-          atendimentos_em_andamento: 0,
-          atendimento__concluído: 0,
-          encaminhamentos: 0
+          atendimentos_em_andamento_calculado_: 0,
+          atendimentos_concludos_calculado_: 0,
+          encaminhamentos_realizados_calculado_: 0
         }
         requester_pivot = requesters[i.requester_id]
       }
 
       // Atualiza os atendimentos em andamento:
       if (i.status_acolhimento === 'atendimento__iniciado') {
-        requester_pivot.atendimentos_em_andamento = requester_pivot.atendimentos_em_andamento + 1
+        requester_pivot.atendimentos_em_andamento_calculado_ = requester_pivot.atendimentos_em_andamento_calculado_ + 1
       } else if (i.status_acolhimento === 'atendimento__concluído') {
-        requester_pivot.atendimento__concluído = requester_pivot.atendimento__concluído + 1
+        requester_pivot.atendimentos_concludos_calculado_ = requester_pivot.atendimentos_concludos_calculado_ + 1
       } else if (i.status_acolhimento === 'encaminhamento__realizado' || i.status_acolhimento === 'encaminhamento__realizado_para_serviço_público') {
-        requester_pivot.encaminhamentos = requester_pivot.encaminhamentos + 1
+        requester_pivot.encaminhamentos_realizados_calculado_ = requester_pivot.encaminhamentos_realizados_calculado_ + 1
       }
     }
 

--- a/packages/cli-zendesk-ticket/src/countTickets.ts
+++ b/packages/cli-zendesk-ticket/src/countTickets.ts
@@ -1,0 +1,88 @@
+import { Ticket } from "./cli";
+import updateTicketRelation from "./updateTicketRelation";
+// import updateTicketRelation from "./updateTicketRelation";
+
+export interface TicketIds {
+  [s: number]: Ticket
+}
+
+interface Requester {
+  atendimentos_em_andamento: number
+  atendimento__concluído: number
+  encaminhamentos: number
+}
+
+interface Requesters {
+  [s: number]: Requester
+}
+
+const countTickets = async (tickets: Ticket[], ticketIds: TicketIds) => {
+  const requesters: Requesters = {}
+  const promises = tickets.map(async i => {
+    let type: 'voluntaria' | 'msr' | null = null
+    if (!i.link_match) {
+      console.log('Não tem link match', i)
+      return
+    }
+
+    let matchId: number
+    try {
+      matchId = Number(i.link_match.split('/').slice(-1)[0])
+    } catch (e) {
+      console.log('Falhou ao gerar o link do match!', i.id)
+      return
+    }
+
+    if (isNaN(matchId)) {
+      console.log('É NaN', i.id)
+      return
+    }
+
+    const ticketId = ticketIds[matchId]
+    if (!ticketId) {
+      console.log('Ticket match parece que não existe! :(', matchId)
+      return
+    }
+
+    if (i.nome_msr) {
+      type = 'msr'
+    } else if (i.nome_voluntaria) {
+      type = 'voluntaria'
+    } else if (i.nome_msr && i.nome_voluntaria) {
+      type = null
+    } else {
+      type = null
+    }
+
+    if (type === 'msr') {
+      // Cria um pivô e inicializa o valor
+      let requester_pivot = requesters[ticketId.requester_id]
+      if (!requesters[ticketId.requester_id]) {
+        requesters[ticketId.requester_id] = {
+          atendimentos_em_andamento: 0,
+          atendimento__concluído: 0,
+          encaminhamentos: 0
+        }
+        requester_pivot = requesters[ticketId.requester_id]
+      }
+
+      // Atualiza os atendimentos em andamento:
+      if (i.status_acolhimento === 'atendimento__iniciado') {
+        requester_pivot.atendimentos_em_andamento = requester_pivot.atendimentos_em_andamento + 1
+      } else if (i.status_acolhimento === 'atendimento__concluído') {
+        requester_pivot.atendimento__concluído = requester_pivot.atendimento__concluído + 1
+      } else if (i.status_acolhimento === 'encaminhamento__realizado' || i.status_acolhimento === 'encaminhamento__realizado_para_serviço_público') {
+        requester_pivot.encaminhamentos = requester_pivot.encaminhamentos + 1
+      }
+    }
+
+    // const { id } = ticketId
+    // const { id: webhooks_registry_id } = i
+
+    // await updateTicketRelation(id, webhooks_registry_id)
+  })
+
+  await Promise.all(promises)
+}
+
+export default countTickets

--- a/packages/cli-zendesk-ticket/src/integrations/Base.ts
+++ b/packages/cli-zendesk-ticket/src/integrations/Base.ts
@@ -12,20 +12,14 @@ abstract class Base {
 
   protected dbg: Debugger
 
-  protected url: string
-
-  private method: 'GET' | 'POST' | 'PUT'
-
-  constructor (name: string, url: string, method: 'GET' | 'POST' | 'PUT' = 'POST') {
-    this.method = method
+  constructor (name: string) {
     this.name = `webhooks-zendesk:${name}`
     this.dbg = debug(this.name)
-    this.url = url
   }
 
-  protected send = async <T>(page?: string) => {
+  protected get = async <T>(url: string, params?: any) => {
     const { ZENDESK_API_URL, ZENDESK_API_TOKEN, ZENDESK_API_USER } = process.env
-    const endpoint = urljoin(ZENDESK_API_URL!, this.url)
+    const endpoint = urljoin(ZENDESK_API_URL!, url)
     let result
     try {
       result = await axios.get<T>(endpoint, {
@@ -33,8 +27,23 @@ abstract class Base {
           username: ZENDESK_API_USER,
           password: ZENDESK_API_TOKEN
         },
-        params: {
-          page
+        params
+      })
+      return result
+    } catch (e) {
+      this.dbg(JSON.stringify(e.response.data, null, 2))
+    }
+  }
+
+  protected put = async <T>(url: string, data?: any) => {
+    const { ZENDESK_API_URL, ZENDESK_API_TOKEN, ZENDESK_API_USER } = process.env
+    const endpoint = urljoin(ZENDESK_API_URL!, url)
+    let result
+    try {
+      result = await axios.put<T>(endpoint, data, {
+        auth: {
+          username: ZENDESK_API_USER,
+          password: ZENDESK_API_TOKEN
         }
       })
       return result

--- a/packages/cli-zendesk-ticket/src/integrations/ListTickets.test.ts
+++ b/packages/cli-zendesk-ticket/src/integrations/ListTickets.test.ts
@@ -8,7 +8,7 @@ describe('Test ListTickets', () => {
     listTickets = new ListTickets()
   })
   test('Connect to zendesk, and get some tickets', async () => {
-    const tickets = await listTickets.start('1')
+    const tickets = await listTickets.start(1)
     expect(tickets).toBeTruthy()
   })
 })

--- a/packages/cli-zendesk-ticket/src/integrations/ListTickets.ts
+++ b/packages/cli-zendesk-ticket/src/integrations/ListTickets.ts
@@ -9,11 +9,11 @@ export interface TicketResponse {
 
 class ListTickets extends Base {
   constructor () {
-    super('ListTickets', `tickets`, 'GET')
+    super('ListTickets')
   }
 
-  start = async (page?: string) => {
-    return this.send<TicketResponse>(page)
+  start = async (page: number) => {
+    return this.get<TicketResponse>('tickets', {page})
   }
 }
 export default ListTickets

--- a/packages/cli-zendesk-ticket/src/integrations/UpdateRequesterFields.ts
+++ b/packages/cli-zendesk-ticket/src/integrations/UpdateRequesterFields.ts
@@ -1,0 +1,29 @@
+import Base from './Base'
+import { Requester } from '../countTickets'
+
+interface UpdateRequesterFieldsRequest extends Requester {
+  id: number
+}
+
+class UpdateRequesterFields extends Base {
+  constructor () {
+    super('UpdateRequesterFields')
+  }
+
+  start = async (requestData: UpdateRequesterFieldsRequest[]) => {
+    const data = {
+      users: requestData.map(i => {
+        const {id, ...customFieldsWithoutId} = i
+        return {
+          id,
+          user_fields: {
+            ...customFieldsWithoutId
+          }
+        }
+      })
+    }
+    return this.put(`users/update_many`, data)
+  }
+}
+
+export default UpdateRequesterFields

--- a/packages/cli-zendesk-ticket/src/saveTickets.ts
+++ b/packages/cli-zendesk-ticket/src/saveTickets.ts
@@ -1,5 +1,5 @@
 import axios from 'axios'
-import { Ticket } from '../cli'
+import { Ticket } from './cli'
 
 const mutation = `mutation (
   $assignee_id: bigint
@@ -88,7 +88,7 @@ const mutation = `mutation (
   }
 }`
 
-const saveTickets = async ({
+const saveTicket = async ({
   assignee_id,
   created_at,
   custom_fields,
@@ -154,4 +154,4 @@ const saveTickets = async ({
   return response
 }
 
-export default saveTickets
+export default saveTicket

--- a/packages/cli-zendesk-ticket/src/updateTicketRelation.ts
+++ b/packages/cli-zendesk-ticket/src/updateTicketRelation.ts
@@ -1,0 +1,39 @@
+import axios from 'axios'
+
+const mutation = `mutation(
+  $id: Int
+  $webhooks_registry_id: Int
+) {
+  update_solidarity_zd_tickets(
+    where: {
+      id: {
+        _eq: $id
+      }
+    }
+    _set: {
+      webhooks_registry_id: $webhooks_registry_id
+    }
+  ) {
+    affected_rows
+  }
+}
+`
+
+const updateTicketRelation = async (id: number, webhooks_registry_id: number) => {
+  const { HASURA_API_URL, X_HASURA_ADMIN_SECRET } = process.env
+  const response = await axios.post(HASURA_API_URL, {
+    query: mutation,
+    variables: {
+      id,
+      webhooks_registry_id
+    }
+  }, {
+    headers: {
+      'x-hasura-admin-secret': X_HASURA_ADMIN_SECRET
+    }
+  })
+
+  return response
+}
+
+export default updateTicketRelation

--- a/packages/webhooks-zendesk-ticket/nodemon.json
+++ b/packages/webhooks-zendesk-ticket/nodemon.json
@@ -1,4 +1,0 @@
-{
-  "verbose": true,
-  "watch": "./dist"
-}


### PR DESCRIPTION
#### Contexto

Esse PR faz atualiza o cli-zendesk-tickets para fazer a contagem dos tickets.

O fluxo de funcionamento do script se dá na seguinte ordem:

1. Puxar todos os tickets do zendesk, de 100 em 100 e armazenar na variável `tickets`
2. Tratar todos os custom_fields e transformá-los em campos na raiz do ticket e armazenar na variável `ticketsWithCustomFields`
3. Realizar a contagem dos tickets, criando uma variável do tipo `Requesters` chamada `requesters`
4. [a fazer] Atualizar usuários no zendesk com essas informações.
5. [a fazer] Puxar todos os dados de tickets do Hasura, atualizar com as relações entre si e salvar novamente.
6. [verificar se é necessário] Salvar também os usuários do zendesk no banco, pois falta a informação dos ids do zendesk no banco de dados, por exemplo, fora a parte em que trabalhar firetamente com os dados no `form_entries` não é nada intuitivo.
7. [proposta de modelagem] Se salvarmos o id do ticket do zendesk como chave primária dos tickets no banco de dados do Hasura, a integração se torna mais simples pois não será mais necessário salvar todos os tickets para gerar um id para cada, antes de poder atualizar as relações.

##### Detalhamento
São armazenados três campos nessa variável `requester`: `atendimentos_em_andamento`, `atendimento__concluído` e `encaminhamentos`.
O próximo passo deve ser iterar esse objeto e atualizar todos os requesters do zendesk com as informações atualizadas.
Estrutura da interface `Requesters`:
```typescript
interface Requester {
  atendimentos_em_andamento: number
  atendimento__concluído: number
  encaminhamentos: number
}
interface Requesters {
  [s: number]: Requester
}
```