### PR TITLE
feat: add solidarity-match to drone

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -59,6 +59,18 @@ pipeline:
       status: success
       branch: [hotfix/*, release/*, feature/*, support/*, develop]
 
+  webhooks-solidarity-match-staging-publish:
+    image: plugins/docker
+    repo: nossas/bonde-webhooks-solidarity-match
+    group: publishing
+    secrets: [ docker_username, docker_password ]
+    dockerfile: packages/webhooks-solidarity-match/Dockerfile
+    tags:
+      - ${DRONE_BRANCH/\//-}
+    when:
+      status: success
+      branch: [hotfix/*, release/*, feature/*, support/*, develop]
+
   webhooks-auth-staging-deploy:
     image: peloton/drone-rancher
     url: http://cluster.bonde.org


### PR DESCRIPTION
#### Contexto

Esse PR adiciona o `webhooks-solidarity-match` ao drone. Havia esquecido de adicionar esse microserviço como parte do processo de CI.