### PR TITLE
fix(cli-zendesk): repeated users and tickets

### DIFF
--- a/packages/cli-zendesk/src/hasura/saveUsers.ts
+++ b/packages/cli-zendesk/src/hasura/saveUsers.ts
@@ -221,7 +221,7 @@ const saveUsers = async (users: User[]) => {
     },
   })
 
-  response.data.errors && dbg(response.data.errors)
+  response.data.errors && dbg(response.data.errors[0])
 
   return response
 }

--- a/packages/cli-zendesk/src/interfaces/User.ts
+++ b/packages/cli-zendesk/src/interfaces/User.ts
@@ -2,45 +2,45 @@ interface User {
   active: boolean
   address: string
   alias: string
-  atendimentos_concludos_calculado_: bigint
-  atendimentos_concluidos: bigint
-  atendimentos_em_andamento: bigint
-  atendimentos_em_andamento_calculado_: bigint
+  atendimentos_concludos_calculado_: number
+  atendimentos_concluidos: number
+  atendimentos_em_andamento: number
+  atendimentos_em_andamento_calculado_: number
   cep: string
   chat_only: boolean
   city: string
   condition: string
   cor: string
   created_at: string
-  custom_role_id: bigint
+  custom_role_id: number
   data_de_inscricao_no_bonde: string | null
-  default_group_id: bigint
+  default_group_id: number
   details: string
   disponibilidade_de_atendimentos: string
   email: string
-  encaminhamentos: bigint
-  encaminhamentos_realizados_calculado_: bigint
-  external_id: bigint
+  encaminhamentos: number
+  encaminhamentos_realizados_calculado_: number
+  external_id: number
   iana_time_zone: string
   id: number
   last_login_at: string
   latitude: string
   locale: string
-  locale_id: bigint
+  locale_id: number
   longitude: string
   moderator: boolean
   name: string
   notes: string
   occupation_area: string
   only_private_comments: boolean
-  organization_id: bigint
+  organization_id: number
   phone: string
   photo: any
   registration_number: string
   report_csv: boolean
   restricted_agent: boolean
   role: string
-  role_type: bigint
+  role_type: number
   shared: boolean
   shared_agent: boolean
   shared_phone_number: string
@@ -56,7 +56,7 @@ interface User {
   updated_at: string
   url: string
   user_fields: any
-  user_id: bigint
+  user_id: number
   verified: boolean
   whatsapp: string
 }


### PR DESCRIPTION
#### Contexto

Esse PR resolve um problema de integração no cli-zendesk, em que a api-incremental do zendesk está retornando usuários duplicados, e isso causa problemas na hora da inserção no Hasura.

O problema foi resolvido removendo-se as duplicatas dos usuários e tickets antes de inserí-los no banco de dados.

Resolves #84 