### PR TITLE
Fix timestamp formatter and query filter from available volunteers

### DIFF
--- a/packages/solidarity-client/server/volunteersAvailable.ts
+++ b/packages/solidarity-client/server/volunteersAvailable.ts
@@ -36,14 +36,16 @@ const main = async (req, res, next) => {
   })
 
   const today = new Date()
-  const last_month = today.getDate() - 30
-  const timestamp = new Date(new Date().setDate(last_month))
+  // get last month and format
+  const last_month = new Date().setDate((today.getDate() - 30)) 
+  // format last_month timestamp
+  const timestamp = new Date(last_month).toISOString()
   const pendingTickets = await getSolidarityMatches({
     query: `query ($last_month: timestamp!){
       solidarity_matches(
         order_by: {created_at: desc}
         where: {
-          created_at: {_gte: $last_month},
+          created_at: {_lte: $last_month},
           status: {_eq: "encaminhamento__realizado"}
         }
       ) {


### PR DESCRIPTION
Os valores de disponibilidade das voluntarias nao estavam sendo atualizados conforme novos encaminhamentos eram feitos. 

Isso ocorreu pois:
- Havia um erro ao setar a data formatada dos ultimos 30 dias e;
- O filtro da query que busca os tickets de match da volutnaria estava incorreto, não era "gte", mas sim "lte". 