### PR TITLE
Hotfix/v1.0.x

### DIFF
--- a/packages/listener-redes-geolocation/src/geolocation.ts
+++ b/packages/listener-redes-geolocation/src/geolocation.ts
@@ -92,10 +92,7 @@ const convertCepToAddressWithGoogleApi = async (
       city: "ZERO_RESULTS"
     };
 
-    return {
-      error: GMAPS_ERRORS.INVALID_INPUT,
-      ...i
-    };
+    return i
   } if (data.status === "OK") {
     const {
       results: [

--- a/packages/listener-redes-geolocation/src/individuals.ts
+++ b/packages/listener-redes-geolocation/src/individuals.ts
@@ -29,12 +29,17 @@ mutation update_rede_individuals($id: Int!, $address: String!, $state: String!, 
 `
 
 export const mutationUpdateCoordinates = async (individual: ConvertCepRes): Promise<Record<string, string>> => {
-  const { data: { update_rede_individuals: { returning: updatedIndividual } } } = await GraphQLAPI.mutate({
-		mutation: REDE_INDIVIDUAL_GEOLOCATION_MUTATION,
-    variables: individual
-	})
-
-	return updatedIndividual
+  try {
+    const { data: { update_rede_individuals: { returning: updatedIndividual } } } = await GraphQLAPI.mutate({
+      mutation: REDE_INDIVIDUAL_GEOLOCATION_MUTATION,
+      variables: individual
+    })
+  
+    return updatedIndividual
+  } catch (err) {
+		logger.log('failed on mutation update coordinates: ', err)
+		return undefined
+	}
 }
 
 export const geolocation = async (response: SubscribeIndividualsResponse) => {

--- a/packages/listener-redes-geolocation/src/types/geolocation.ts
+++ b/packages/listener-redes-geolocation/src/types/geolocation.ts
@@ -33,4 +33,4 @@ export interface GoogleMapsAddressComponent {
 
 export type IndividualGeolocation = Omit<Individual, 'created_at'| 'zipcode'>
 
-export type ConvertCepRes = IndividualGeolocation | IndividualGeolocation & { error: GMAPS_ERRORS } | { error: GMAPS_ERRORS }
+export type ConvertCepRes = IndividualGeolocation | { error: GMAPS_ERRORS }

--- a/packages/listener-redes/src/features/settings/fetchRedesGroups.ts
+++ b/packages/listener-redes/src/features/settings/fetchRedesGroups.ts
@@ -17,12 +17,17 @@ query redes {
 `
 
 const fetchRedesGroups = async (): Promise<any> => {
-	const { data: { rede_groups: groups } } = await GraphQLAPI.query({
-		query: FETCH_REDES_QUERY,
-		fetchPolicy: 'network-only'
-	})
-
-	return groups
+  try {
+    const { data: { rede_groups: groups } } = await GraphQLAPI.query({
+      query: FETCH_REDES_QUERY,
+      fetchPolicy: 'network-only'
+    })
+  
+    return groups
+  } catch (err) {
+		console.error('failed on fetch redes groups: '.red, err)
+		return undefined
+	}
 }
 
 export default fetchRedesGroups

--- a/packages/listener-redes/src/features/settings/insertRedeIndividuals.ts
+++ b/packages/listener-redes/src/features/settings/insertRedeIndividuals.ts
@@ -37,12 +37,17 @@ mutation insert_rede_individuals ($individuals: [rede_individuals_insert_input!]
 `
 
 const insertRedeIndividuals = async (individuals: any): Promise<any> => {
-	const { data: { insert_rede_individuals: { returning } } } = await GraphQLAPI.mutate({
-		mutation: INDIVIDUALS_MUTATION,
-    variables: { individuals }
-	})
-
-	return returning
+  try {
+    const { data: { insert_rede_individuals: { returning } } } = await GraphQLAPI.mutate({
+      mutation: INDIVIDUALS_MUTATION,
+      variables: { individuals }
+    })
+  
+    return returning
+  } catch (err) {
+		console.error('failed on insert rede individuals: '.red, err)
+		return undefined
+	}
 }
 
 export default insertRedeIndividuals

--- a/packages/listener-redes/src/features/settings/subscriptionFormEntries.ts
+++ b/packages/listener-redes/src/features/settings/subscriptionFormEntries.ts
@@ -73,7 +73,7 @@ const handleNext = (widgets: Widget[]) => async (response: any) => {
 			}
 		})
 
-		// console.log('individuals', individuals)
+		console.log('individuals', individuals)
 		// Batch insert individuals
 		console.log('Inserting the new individuals on GraphQL API...')
 		await insertRedeIndividuals(individuals)

--- a/packages/listener-redes/src/features/settings/subscriptionFormEntries.ts
+++ b/packages/listener-redes/src/features/settings/subscriptionFormEntries.ts
@@ -73,7 +73,7 @@ const handleNext = (widgets: Widget[]) => async (response: any) => {
 			}
 		})
 
-		console.log('individuals', individuals)
+		// console.log('individuals', individuals)
 		// Batch insert individuals
 		console.log('Inserting the new individuals on GraphQL API...')
 		await insertRedeIndividuals(individuals)

--- a/packages/listener-redes/src/features/settings/updateFormEntries.ts
+++ b/packages/listener-redes/src/features/settings/updateFormEntries.ts
@@ -13,12 +13,17 @@ mutation update_form_entries ($forms: [Int!]) {
 `
 
 const updateFormEntries = async (forms: number[]): Promise<any> => {
-	const { data: { update_form_entries: { returning: formEntries } } } = await GraphQLAPI.mutate({
-		mutation: FORM_ENTRIES_MUTATION,
-    variables: { forms }
-	})
-
-	return formEntries
+  try {
+    const { data: { update_form_entries: { returning: formEntries } } } = await GraphQLAPI.mutate({
+      mutation: FORM_ENTRIES_MUTATION,
+      variables: { forms }
+    })
+  
+    return formEntries
+  } catch (err) {
+		console.error('failed on update form entries: '.red, err)
+		return undefined
+	}
 }
 
 export default updateFormEntries


### PR DESCRIPTION
- Adiciona catch em todas as promises pra api graphql nos listeners
- Muda o objeto individual que é retornado pela função `convertCepToAddressWithGoogleApi` caso o retorno da api do maps seja ruim.
- - Isso porque a mutation que vai receber esse objeto não lida com esse erro, então não faz sentido retornar ele ali